### PR TITLE
posts(learning-to-fly-pt3): needed for rng.gen_bool()

### DIFF
--- a/src/content/en/posts/learning-to-fly-pt3.adoc
+++ b/src/content/en/posts/learning-to-fly-pt3.adoc
@@ -1570,6 +1570,8 @@ pub trait CrossoverMethod {
 
 [source, rust]
 ----
+use rand::Rng;
+
 #[derive(Clone, Debug)]
 pub struct UniformCrossover;
 


### PR DESCRIPTION
In practice I changed  `use rand::RngCore;` to `use rand::{Rng, RngCore};` that we added on line 384, (so maybe it would be easier to declare it in the first place?)