### PR TITLE
solution for pub struct TestIndividual

### DIFF
--- a/src/content/en/posts/learning-to-fly-pt3.adoc
+++ b/src/content/en/posts/learning-to-fly-pt3.adoc
@@ -2294,6 +2294,25 @@ impl AsRef<Chromosome> for TestIndividual {
 ----
 ====
 
+Rather than simply:
+[souce, rust]
+----
+#[cfg(test)]
+impl Individual for TestIndividual {
+    fn create(chromosome: Chromosome) -> Self {
+        TestIndividual::new(chromosome.genes[0])
+    }
+
+    fn fitness(&self) -> f32 {
+        self.fitness
+    }
+
+    fn chromosome(&self) -> &Chromosome {
+        panic!("not supported for TestIndividual")
+    }
+}
+----
+
 Back to the loop:
 
 [source, rust]


### PR DESCRIPTION
L710 `pub struct TestIndividual`
and then TestIndividual evolves into
L2381  `pub enum TestIndividual`
without ensuring that the previous section still passes `for i in fmt check test;do cargo $i; done`